### PR TITLE
Auto-discover WebGPU tests from `mozilla-central` checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +793,7 @@ dependencies = [
  "insta",
  "log",
  "miette",
+ "natord",
  "path-dsl",
  "regex",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,12 +431,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -430,6 +481,15 @@ name = "path-dsl"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d19dd56d2bd4b2e19d415532597c1b0366f096212a27980ac4115f29ebe0c74"
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -504,6 +564,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -665,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +750,31 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+dependencies = [
+ "const_format",
+ "itertools",
+ "nom",
+ "pori",
+ "regex",
+ "thiserror",
+ "walkdir",
+]
 
 [[package]]
 name = "whippit"
@@ -690,6 +790,7 @@ dependencies = [
  "path-dsl",
  "regex",
  "thiserror",
+ "wax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 path-dsl = "0.6.1"
 regex = "1.9.5"
 thiserror = "1.0.49"
+wax = "0.6.0"
 
 [dev-dependencies]
 insta = "1.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ env_logger = "0.10.0"
 indexmap = "2.0.0"
 log = "0.4.20"
 miette = { version = "5.10.0", features = ["fancy"] }
+natord = "1.0.9"
 path-dsl = "0.6.1"
 regex = "1.9.5"
 thiserror = "1.0.49"

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,9 +168,9 @@ fn run(cli: Cli) -> ExitCode {
     }
 }
 
-/// Returns a "list of files found by searching for `glob_pattern` in `base`. `gecko_checkout` is
-/// stripped as a prefix from the absolute paths recorded into `log` entries emitted by this
-/// function.
+/// Returns a "naturally" sorted list of files found by searching for `glob_pattern` in `base`.
+/// `gecko_checkout` is stripped as a prefix from the absolute paths recorded into `log` entries
+/// emitted by this function.
 ///
 /// # Panics
 ///
@@ -181,7 +181,7 @@ fn read_gecko_files_at(
     glob_pattern: &str,
 ) -> Result<IndexMap<PathBuf, Arc<String>>, ()> {
     let mut found_read_err = false;
-    let paths = wax::Glob::new(glob_pattern)
+    let mut paths = wax::Glob::new(glob_pattern)
         .unwrap()
         .walk(&base)
         .filter_map(|entry| match entry {
@@ -203,6 +203,9 @@ fn read_gecko_files_at(
             }
         })
         .collect::<Vec<_>>();
+
+    paths.sort_by(|a, b| natord::compare(a.to_str().unwrap(), b.to_str().unwrap()));
+    let paths = paths;
 
     log::info!(
         "working with these files: {:#?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    fmt::Display,
     fs,
     path::{Path, PathBuf},
     process::ExitCode,
@@ -41,51 +42,30 @@ fn run(cli: Cli) -> ExitCode {
     } = cli;
     match subcommand {
         Subcommand::DumpTestExps => {
-            let raw_test_files_by_path = {
-                let mut found_read_err = false;
-                let data = (1..=51)
-                    .filter_map(|chunk| {
-                        let wpt_expectation_file_path = {
-                            let chunk = chunk.to_string();
-                            path!(
-                                &gecko_checkout
-                                    | "testing"
-                                    | "web-platform"
-                                    | "mozilla"
-                                    | "meta"
-                                    | "webgpu"
-                                    | "chunked"
-                                    | &chunk
-                                    | "cts.https.html.ini"
-                            )
-                        };
-                        log::debug!("reading from {}…", wpt_expectation_file_path.display());
-                        match fs::read_to_string(&wpt_expectation_file_path) {
-                            Err(e) => {
-                                log::error!("failed to read {wpt_expectation_file_path:?}: {e}");
-                                found_read_err = true;
-                                None
-                            }
-                            Ok(contents) => Some((
-                                wpt_expectation_file_path
-                                    .strip_prefix(&gecko_checkout)
-                                    .unwrap()
-                                    .to_owned(),
-                                Arc::new(contents),
-                            )),
-                        }
-                    })
-                    .collect::<IndexMap<_, _>>();
-                if found_read_err {
-                    return ExitCode::FAILURE;
-                }
-                data
+            let webgpu_cts_meta_parent_dir = {
+                path!(
+                    &gecko_checkout
+                        | "testing"
+                        | "web-platform"
+                        | "mozilla"
+                        | "meta"
+                        | "webgpu"
+                        | "chunked"
+                )
             };
+
             #[derive(Debug)]
             struct Test<'a> {
                 orig_path: &'a Path,
                 inner: metadata::Test<'a>,
             }
+
+            let raw_test_files_by_path =
+                match read_gecko_files_at(&gecko_checkout, &webgpu_cts_meta_parent_dir, "**/*.ini")
+                {
+                    Ok(paths) => paths,
+                    Err(()) => return ExitCode::FAILURE,
+                };
             let tests_by_name = {
                 let mut found_parse_err = false;
                 let extracted = raw_test_files_by_path
@@ -148,33 +128,26 @@ fn run(cli: Cli) -> ExitCode {
             ExitCode::SUCCESS
         }
         Subcommand::ReadTestVariants => {
-            let tests_by_path = (1..=51)
-                .map(|chunk| {
-                    let wpt_file_path = {
-                        let chunk = chunk.to_string();
-                        path!(
-                            &gecko_checkout
-                                | "testing"
-                                | "web-platform"
-                                | "mozilla"
-                                | "tests"
-                                | "webgpu"
-                                | "chunked"
-                                | &chunk
-                                | "cts.https.html"
-                        )
-                    };
-                    eprintln!("{}", wpt_file_path.display());
-                    let contents = fs::read_to_string(&wpt_file_path).unwrap();
-                    (
-                        wpt_file_path
-                            .strip_prefix(&gecko_checkout)
-                            .unwrap()
-                            .to_owned(),
-                        contents,
-                    )
-                })
-                .collect::<IndexMap<_, _>>();
+            let webgpu_cts_test_parent_dir = {
+                path!(
+                    &gecko_checkout
+                        | "testing"
+                        | "web-platform"
+                        | "mozilla"
+                        | "tests"
+                        | "webgpu"
+                        | "chunked"
+                )
+            };
+
+            let tests_by_path = match read_gecko_files_at(
+                &gecko_checkout,
+                &webgpu_cts_test_parent_dir,
+                "**/cts.https.html",
+            ) {
+                Ok(paths) => paths,
+                Err(()) => return ExitCode::FAILURE,
+            };
 
             let meta_variant_re =
                 Regex::new(r"^<meta name=variant content='\?q=(?P<variant_path>.*?)'>$").unwrap();
@@ -193,4 +166,74 @@ fn run(cli: Cli) -> ExitCode {
             ExitCode::SUCCESS
         }
     }
+}
+
+/// Returns a "list of files found by searching for `glob_pattern` in `base`. `gecko_checkout` is
+/// stripped as a prefix from the absolute paths recorded into `log` entries emitted by this
+/// function.
+///
+/// # Panics
+///
+/// This function will panick if `gecko_checkout` cannot be stripped as a prefix of `base`.
+fn read_gecko_files_at(
+    gecko_checkout: &Path,
+    base: &Path,
+    glob_pattern: &str,
+) -> Result<IndexMap<PathBuf, Arc<String>>, ()> {
+    let mut found_read_err = false;
+    let paths = wax::Glob::new(glob_pattern)
+        .unwrap()
+        .walk(&base)
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path().to_owned()),
+            Err(e) => {
+                let path_disp = e
+                    .path()
+                    .map(|p| format!(" in {}", p.strip_prefix(&gecko_checkout).unwrap().display()));
+                let path_disp: &dyn Display = match path_disp.as_ref() {
+                    Some(disp) => disp,
+                    None => &"",
+                };
+                log::error!(
+                    "failed to enumerate `cts.https.html` files{}\n  caused by: {e}",
+                    path_disp
+                );
+                found_read_err = true;
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    log::info!(
+        "working with these files: {:#?}",
+        paths
+            .iter()
+            .map(|f| f.strip_prefix(&gecko_checkout).unwrap())
+            .collect::<std::collections::BTreeSet<_>>()
+    );
+
+    if found_read_err {
+        return Err(());
+    }
+
+    let files = paths
+        .into_iter()
+        .filter_map(|file| {
+            log::debug!("reading from {}…", file.display());
+            match fs::read_to_string(&file) {
+                Err(e) => {
+                    log::error!("failed to read {file:?}: {e}");
+                    found_read_err = true;
+                    None
+                }
+                Ok(contents) => Some((file, Arc::new(contents))),
+            }
+        })
+        .collect::<IndexMap<_, _>>();
+
+    if found_read_err {
+        return Err(());
+    }
+
+    Ok(files)
 }


### PR DESCRIPTION
- feat(cli)!: auto-discover WebGPU CTS tests by glob, not baked-in chunk count
- refactor(cli)!: apply natural sort to enumerated file paths
